### PR TITLE
Fix for incorrect listview behaviour on Android

### DIFF
--- a/TwinTechsForms/TwinTechsForms.Droid/TwinTechs/Droid/Controls/FastCellRenderer.cs
+++ b/TwinTechsForms/TwinTechsForms.Droid/TwinTechs/Droid/Controls/FastCellRenderer.cs
@@ -86,15 +86,21 @@ namespace TwinTechs.Droid.Controls
 		{
 			var cellCache = FastCellCache.Instance.GetCellCache (parent);
 			var fastCell = item as FastCell;
+			
 			Android.Views.View cellCore = convertView;
+			
 			if (cellCore != null && cellCache.IsCached (cellCore)) {
 				cellCache.RecycleCell (cellCore, fastCell);
 			} else {
-				if (!fastCell.IsInitialized) {
-					fastCell.PrepareCell ();
+				var newCell = (FastCell) Activator.CreateInstance (item.GetType ());
+				newCell.BindingContext = item.BindingContext;
+				newCell.Parent = item.Parent;				
+
+				if (!newCell.IsInitialized) {
+					newCell.PrepareCell ();
 				}
-				cellCore = base.GetCellCore (fastCell, convertView, parent, context);
-				cellCache.CacheCell (fastCell, cellCore);
+				cellCore = base.GetCellCore (newCell, convertView, parent, context);
+				cellCache.CacheCell (newCell, cellCore);
 			}
 			return cellCore;
 		}


### PR DESCRIPTION
This change creates new cells instead of reusing the given Cell objects from the listview creating unstable behaviour (item selected/tapped not returning the expected item).

The caching of original binding context is now irrelevant, this can be removed from the cell cache.

This bug can be reproduced with the FastSimpleCellLots.xaml page by scrolling about halfway down and back up, the first item in the list returns a different object than expected.

This fix is only for Android but can be applied to iOS aswell
